### PR TITLE
Deduplicate generated types.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ all APIs might be changed.
 ### New Features
 
 - Internally tagged enums are now supported
+- `go-away` now deduplicates types so if a given type appears in more than one
+  place it should only result in one go type being output.
 
 ## v0.1.1 - 2021-05-26
 

--- a/go-away-derive-internals/src/type_metadata_derive/snapshots/go_away_derive_internals__type_metadata_derive__tests__struct.snap
+++ b/go-away-derive-internals/src/type_metadata_derive/snapshots/go_away_derive_internals__type_metadata_derive__tests__struct.snap
@@ -22,7 +22,7 @@ impl ::go_away::TypeMetadata for MyData {
                 serialized_name: "field_two".into(),
                 ty: <String as ::go_away::TypeMetadata>::metadata(registry),
             });
-            registry.register_struct(st)
+            registry.register_struct(::go_away::TypeId::for_type::<MyData>(), st)
         };
         FieldType::Named(type_ref)
     }

--- a/go-away-derive-internals/src/type_metadata_derive/type_id.rs
+++ b/go-away-derive-internals/src/type_metadata_derive/type_id.rs
@@ -70,6 +70,10 @@ impl<'a> ToTokens for VariantTypeIdCall<'a> {
     }
 }
 
+/// Some generics, but with all the lifetimes replaced with 'static.
+///
+/// We need this to call `TypeId::of` because it doesn't like non static
+/// lifetimes
 struct StaticGenerics<'a>(&'a syn::Generics);
 
 impl<'a> quote::ToTokens for StaticGenerics<'a> {

--- a/go-away-derive-internals/src/type_metadata_derive/type_id.rs
+++ b/go-away-derive-internals/src/type_metadata_derive/type_id.rs
@@ -1,0 +1,137 @@
+use proc_macro2::{Literal, TokenStream};
+use quote::{quote, ToTokens, TokenStreamExt};
+
+pub enum TypeIdCall<'a> {
+    Struct(StructTypeIdCall<'a>),
+    Variant(VariantTypeIdCall<'a>),
+}
+
+impl<'a> TypeIdCall<'a> {
+    pub fn for_struct(ident: &'a syn::Ident, generics: &'a syn::Generics) -> Self {
+        TypeIdCall::Struct(StructTypeIdCall {
+            ident,
+            generics: StaticGenerics(generics),
+        })
+    }
+
+    pub fn for_variant(
+        enum_ident: &'a syn::Ident,
+        variant_name: &'a syn::Ident,
+        generics: &'a syn::Generics,
+    ) -> Self {
+        TypeIdCall::Variant(VariantTypeIdCall {
+            enum_ident,
+            variant_name,
+            generics: StaticGenerics(generics),
+        })
+    }
+}
+
+impl<'a> ToTokens for TypeIdCall<'a> {
+    fn to_tokens(&self, stream: &mut proc_macro2::TokenStream) {
+        match self {
+            Self::Struct(s) => s.to_tokens(stream),
+            Self::Variant(v) => v.to_tokens(stream),
+        }
+    }
+}
+
+pub struct StructTypeIdCall<'a> {
+    ident: &'a syn::Ident,
+    generics: StaticGenerics<'a>,
+}
+
+impl<'a> ToTokens for StructTypeIdCall<'a> {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        let ident = self.ident;
+        let generics = &self.generics;
+
+        tokens.append_all(quote! {
+            ::go_away::TypeId::for_type::<#ident #generics>()
+        })
+    }
+}
+
+pub struct VariantTypeIdCall<'a> {
+    enum_ident: &'a syn::Ident,
+    variant_name: &'a syn::Ident,
+    generics: StaticGenerics<'a>,
+}
+
+impl<'a> ToTokens for VariantTypeIdCall<'a> {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        let enum_ident = self.enum_ident;
+        let variant_name = Literal::string(&self.variant_name.to_string());
+        let generics = &self.generics;
+
+        tokens.append_all(quote! {
+            ::go_away::TypeId::for_variant::<#enum_ident #generics, _>(#variant_name)
+        })
+    }
+}
+
+struct StaticGenerics<'a>(&'a syn::Generics);
+
+impl<'a> quote::ToTokens for StaticGenerics<'a> {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        use syn::{GenericParam, Token};
+
+        if self.0.params.is_empty() {
+            return;
+        }
+
+        TokensOrDefault(&self.0.lt_token).to_tokens(tokens);
+
+        // Print lifetimes before types and consts, regardless of their
+        // order in self.params.
+        //
+        // TODO: ordering rules for const parameters vs type parameters have
+        // not been settled yet. https://github.com/rust-lang/rust/issues/44580
+        let mut trailing_or_empty = true;
+        for param in self.0.params.pairs() {
+            if let GenericParam::Lifetime(_) = *param.value() {
+                // Hard code this lifetime to 'static
+                tokens.append_all(quote! { 'static });
+                param.punct().to_tokens(tokens);
+                trailing_or_empty = param.punct().is_some();
+            }
+        }
+        for param in self.0.params.pairs() {
+            if let GenericParam::Lifetime(_) = **param.value() {
+                continue;
+            }
+            if !trailing_or_empty {
+                <Token![,]>::default().to_tokens(tokens);
+                trailing_or_empty = true;
+            }
+            match *param.value() {
+                GenericParam::Lifetime(_) => unreachable!(),
+                GenericParam::Type(param) => {
+                    // Leave off the type parameter defaults
+                    param.ident.to_tokens(tokens);
+                }
+                GenericParam::Const(param) => {
+                    // Leave off the const parameter defaults
+                    param.ident.to_tokens(tokens);
+                }
+            }
+            param.punct().to_tokens(tokens);
+        }
+
+        TokensOrDefault(&self.0.gt_token).to_tokens(tokens);
+    }
+}
+
+pub struct TokensOrDefault<'a, T: 'a>(pub &'a Option<T>);
+
+impl<'a, T> quote::ToTokens for TokensOrDefault<'a, T>
+where
+    T: quote::ToTokens + Default,
+{
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        match self.0 {
+            Some(t) => t.to_tokens(tokens),
+            None => T::default().to_tokens(tokens),
+        }
+    }
+}

--- a/go-away/src/lib.rs
+++ b/go-away/src/lib.rs
@@ -37,11 +37,13 @@
 mod metadata;
 mod output;
 mod registry;
+mod type_id;
 
 pub mod types;
 
 pub use metadata::TypeMetadata;
 pub use registry::TypeRegistry;
+pub use type_id::TypeId;
 
 pub use go_away_derive::TypeMetadata;
 
@@ -52,18 +54,33 @@ pub fn registry_to_output(registry: TypeRegistry) -> String {
     use std::fmt::Write;
 
     let mut output = String::new();
-    for st in registry.structs {
-        write!(&mut output, "{}", output::GoType::Struct(st)).unwrap();
+    for id in registry.structs {
+        let ty = registry.types.get(&id).unwrap();
+        write!(&mut output, "{}", output::GoType::from(ty)).unwrap();
     }
-    for en in registry.enums {
-        write!(&mut output, "{}", output::GoType::Enum(en)).unwrap();
+    for id in registry.enums {
+        let ty = registry.types.get(&id).unwrap();
+        write!(&mut output, "{}", output::GoType::from(ty)).unwrap();
     }
-    for un in registry.unions {
-        write!(&mut output, "{}", output::GoType::Union(un)).unwrap();
+    for id in registry.unions {
+        let ty = registry.types.get(&id).unwrap();
+        write!(&mut output, "{}", output::GoType::from(ty)).unwrap();
     }
-    for nt in registry.newtypes {
-        write!(&mut output, "{}", output::GoType::NewType(nt)).unwrap();
+    for id in registry.newtypes {
+        let ty = registry.types.get(&id).unwrap();
+        write!(&mut output, "{}", output::GoType::from(ty)).unwrap();
     }
 
     output
+}
+
+impl<'a> From<&'a registry::Type> for output::GoType<'a> {
+    fn from(ty: &'a registry::Type) -> Self {
+        match ty {
+            registry::Type::Struct(inner) => output::GoType::Struct(inner),
+            registry::Type::Enum(inner) => output::GoType::Enum(inner),
+            registry::Type::Union(inner) => output::GoType::Union(inner),
+            registry::Type::NewType(inner) => output::GoType::NewType(inner),
+        }
+    }
 }

--- a/go-away/src/output.rs
+++ b/go-away/src/output.rs
@@ -4,14 +4,14 @@ use indoc::writedoc;
 
 pub use super::types::*;
 
-pub enum GoType {
-    Struct(Struct),
-    NewType(NewType),
-    Enum(Enum),
-    Union(Union),
+pub enum GoType<'a> {
+    Struct(&'a Struct),
+    NewType(&'a NewType),
+    Enum(&'a Enum),
+    Union(&'a Union),
 }
 
-impl fmt::Display for GoType {
+impl<'a> fmt::Display for GoType<'a> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         match self {
             GoType::Struct(details) => {
@@ -361,7 +361,7 @@ mod tests {
     #[test]
     fn test_primitive_structs() {
         assert_snapshot!(
-            GoType::Struct(Struct {
+            GoType::Struct(&Struct {
                 name: "MyStruct".into(),
                 fields: vec![
                     Field {
@@ -400,7 +400,7 @@ mod tests {
 
     #[test]
     fn test_newtype_output() {
-        assert_snapshot!(GoType::NewType(NewType {
+        assert_snapshot!(GoType::NewType(&NewType {
             name: "UserId".into(),
             inner: FieldType::Primitive(Primitive::String),
         })
@@ -410,7 +410,7 @@ mod tests {
 
     #[test]
     fn test_enum_output() {
-        assert_snapshot!(GoType::Enum(Enum {
+        assert_snapshot!(GoType::Enum(&Enum {
             name: "FulfilmentType".into(),
             variants: vec![
                 EnumVariant {
@@ -435,7 +435,7 @@ mod tests {
 
     #[test]
     fn test_adjacently_tagged_union_output() {
-        assert_snapshot!(GoType::Union(Union {
+        assert_snapshot!(GoType::Union(&Union {
             name: "MyUnion".into(),
             representation: UnionRepresentation::AdjacentlyTagged {
                 tag: "type".into(),

--- a/go-away/src/registry.rs
+++ b/go-away/src/registry.rs
@@ -24,7 +24,6 @@ pub struct TypeRegistry {
     pub(super) newtypes: Vec<TypeId>,
 }
 
-// TODO: these methods maybe need to take/return some sort of UUID that identifies the type...
 impl TypeRegistry {
     /// Construct a new TypeRegistry
     pub fn new() -> Self {

--- a/go-away/src/type_id.rs
+++ b/go-away/src/type_id.rs
@@ -1,0 +1,37 @@
+pub use std::borrow::Cow;
+
+/// A type identifier - used to deduplicate types in the output
+#[derive(Hash, Debug, PartialEq, Eq, Clone)]
+pub struct TypeId(TypeIdInner);
+
+impl TypeId {
+    /// Construct a `TypeId` for a given rust type
+    pub fn for_type<T: 'static + ?Sized>() -> Self {
+        TypeId(TypeIdInner::Type(std::any::TypeId::of::<T>()))
+    }
+
+    /// Construct a `TypeId` for a variant of a rust enum.
+    ///
+    /// This needs specific support beacuse our output needs types that
+    /// don't exist directly in rust.
+    pub fn for_variant<T, S>(variant_name: S) -> Self
+    where
+        T: 'static + ?Sized,
+        S: Into<Cow<'static, str>>,
+    {
+        TypeId(TypeIdInner::Variant {
+            parent_enum: std::any::TypeId::of::<T>(),
+            variant_name: variant_name.into(),
+        })
+    }
+}
+
+#[derive(Hash, Debug, PartialEq, Eq, Clone)]
+pub(super) enum TypeIdInner {
+    Type(std::any::TypeId),
+
+    Variant {
+        parent_enum: std::any::TypeId,
+        variant_name: Cow<'static, str>,
+    },
+}

--- a/go-away/src/types.rs
+++ b/go-away/src/types.rs
@@ -4,6 +4,7 @@
 /// A struct.
 ///
 /// This will be serialized as a JSON object.
+#[derive(Debug)]
 pub struct Struct {
     /// The name of the struct in Rust
     pub name: String,
@@ -13,6 +14,7 @@ pub struct Struct {
 }
 
 /// A field within a struct
+#[derive(Debug)]
 pub struct Field {
     /// The name of the field in rust.  If the field is un-named this will
     /// be a number.
@@ -27,6 +29,7 @@ pub struct Field {
 /// A newtype struct (e.g. `struct SomeId(String)`)
 ///
 /// These are usually represented as their inner type when serialized.
+#[derive(Debug)]
 pub struct NewType {
     /// The name of the struct in rust.
     pub name: String,
@@ -38,6 +41,7 @@ pub struct NewType {
 /// An enum - note that in go-away these do not contain data.
 ///
 /// A Rust enum that's variants contain values will go to a `UnionType`
+#[derive(Debug)]
 pub struct Enum {
     /// The name of the enum
     pub name: String,
@@ -47,6 +51,7 @@ pub struct Enum {
 
 /// An enum variant - note that these are just names and are serialized
 /// as strings.
+#[derive(Debug)]
 pub struct EnumVariant {
     /// The name of the variant in code.
     pub name: String,
@@ -57,6 +62,7 @@ pub struct EnumVariant {
 /// A union type - any rust enum that's variants contain data.
 ///
 /// These will be serialzied differently depending on the UnionRepresentation.
+#[derive(Debug)]
 pub struct Union {
     /// The name of the union
     pub name: String,
@@ -66,7 +72,7 @@ pub struct Union {
     pub variants: Vec<UnionVariant>,
 }
 
-#[derive(PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq)]
 /// A variant of a union type
 pub struct UnionVariant {
     /// The name of the variant if any
@@ -80,6 +86,7 @@ pub struct UnionVariant {
 /// The serialized representation of the union type
 ///
 /// See https://serde.rs/enum-representations.html for details
+#[derive(Debug)]
 pub enum UnionRepresentation {
     /// An adjacently tagged representation
     AdjacentlyTagged {
@@ -100,7 +107,7 @@ pub enum UnionRepresentation {
 }
 
 /// The type of a field.
-#[derive(PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum FieldType {
     /// A `Option<T>` field
     Optional(Box<FieldType>),
@@ -120,7 +127,7 @@ pub enum FieldType {
 }
 
 /// The primitive types
-#[derive(PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum Primitive {
     /// Strings
     String,
@@ -133,7 +140,7 @@ pub enum Primitive {
 }
 
 /// A reference to a given named type
-#[derive(PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct TypeRef {
     pub(crate) name: String,
 }

--- a/go-away/tests/output.rs
+++ b/go-away/tests/output.rs
@@ -86,3 +86,14 @@ fn test_internally_tagged_tuple_enum() {
 
     assert_snapshot!(go_away::registry_to_output(registry));
 }
+
+#[test]
+fn type_deduplication() {
+    let mut registry = TypeRegistry::new();
+
+    // These both contain `Nested` so there should be one `Nested` type in the output
+    StructEnum::metadata(&mut registry);
+    MyData::metadata(&mut registry);
+
+    assert_snapshot!(go_away::registry_to_output(registry));
+}

--- a/go-away/tests/snapshots/output__type_deduplication.snap
+++ b/go-away/tests/snapshots/output__type_deduplication.snap
@@ -1,0 +1,79 @@
+---
+source: go-away/tests/output.rs
+expression: "go_away::registry_to_output(registry)"
+
+---
+type OptionOne struct {
+	X string `json:"x"`
+	Y int `json:"y"`
+}
+type Nested struct {
+	AString string `json:"some_other_name"`
+	AnInt int `json:"an_int"`
+	FulfilmentType FulfilmentType `json:"fulfilment_type"`
+}
+type OptionTwo struct {
+	Foo string `json:"foo"`
+	Bar Nested `json:"bar"`
+}
+type MyData struct {
+	FieldOne string `json:"field_one"`
+	Nested Nested `json:"nested"`
+}
+type FulfilmentType string
+
+const (
+	Delivery FulfilmentType = "Delivery"
+	Collection FulfilmentType = "Collection"
+)
+type StructEnum struct {
+	*OptionOne
+	*OptionTwo
+}
+
+func (self *StructEnum) MarshalJSON() ([]byte, error) {
+	if self.OptionOne != nil {
+		var output map[string]interface{}
+		output["type"] = "OptionOne"
+		output["data"] = self.OptionOne
+		return json.Marshal(output)
+	} else 	if self.OptionTwo != nil {
+		var output map[string]interface{}
+		output["type"] = "OptionTwo"
+		output["data"] = self.OptionTwo
+		return json.Marshal(output)
+	} else 	{
+		return json.Marshal(nil)
+	}
+}
+func (self *StructEnum) UnmarshalJSON(data []byte) error {
+	temp := struct{
+		Tag string `json:"type"`
+	}{}
+	if err := json.Unmarshal(data, &temp); err != nil {
+		return err
+	}
+	if temp.Tag == "OptionOne" {
+		rv := struct{
+			Data OptionOne `json:"data"`
+		}{}
+		if err := json.Unmarshal(data, &rv); err != nil {
+			return err
+		}
+		self.OptionOne = &rv.Data
+		self.OptionTwo = nil
+	} else if temp.Tag == "OptionTwo" {
+		rv := struct{
+			Data OptionTwo `json:"data"`
+		}{}
+		if err := json.Unmarshal(data, &rv); err != nil {
+			return err
+		}
+		self.OptionTwo = &rv.Data
+		self.OptionOne = nil
+	} else {
+		return errors.New("Unknown type tag")
+	}
+	return nil
+}
+


### PR DESCRIPTION
This introduces a concept of a `TypeId` that can be used to deduplicate
types that are output.  This is loosely based on the built in rust
`TypeId`, but with some additions to support types for variants (which
can't have a `TypeId` in rust)

I've put some effort into making sure the order of output is the same,
so this shouldn't change in this commit.  Though may want to change it
in the future.

Fixes #3