### PR TITLE
Reverse the output of types within groups.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ all APIs might be changed.
 - `go-away` now deduplicates types so if a given type appears in more than one
   place it should only result in one go type being output.
 
+### Changes
+
+- Messed with the order of output a bit
+
 ## v0.1.1 - 2021-05-26
 
 ### Changes

--- a/go-away/src/lib.rs
+++ b/go-away/src/lib.rs
@@ -54,19 +54,19 @@ pub fn registry_to_output(registry: TypeRegistry) -> String {
     use std::fmt::Write;
 
     let mut output = String::new();
-    for id in registry.structs {
+    for id in registry.structs.into_iter().rev() {
         let ty = registry.types.get(&id).unwrap();
         write!(&mut output, "{}", output::GoType::from(ty)).unwrap();
     }
-    for id in registry.enums {
+    for id in registry.unions.into_iter().rev() {
         let ty = registry.types.get(&id).unwrap();
         write!(&mut output, "{}", output::GoType::from(ty)).unwrap();
     }
-    for id in registry.unions {
+    for id in registry.newtypes.into_iter().rev() {
         let ty = registry.types.get(&id).unwrap();
         write!(&mut output, "{}", output::GoType::from(ty)).unwrap();
     }
-    for id in registry.newtypes {
+    for id in registry.enums.into_iter().rev() {
         let ty = registry.types.get(&id).unwrap();
         write!(&mut output, "{}", output::GoType::from(ty)).unwrap();
     }

--- a/go-away/tests/snapshots/output__internally_tagged_tuple_enum.snap
+++ b/go-away/tests/snapshots/output__internally_tagged_tuple_enum.snap
@@ -55,6 +55,6 @@ func (self *InternallyTaggedTupleEnum) UnmarshalJSON(data []byte) error {
 	}
 	return nil
 }
-type One float64
 type Two bool
+type One float64
 

--- a/go-away/tests/snapshots/output__newtype_enum.snap
+++ b/go-away/tests/snapshots/output__newtype_enum.snap
@@ -53,6 +53,6 @@ func (self *NewTypeEnum) UnmarshalJSON(data []byte) error {
 	}
 	return nil
 }
-type One float64
 type Two bool
+type One float64
 

--- a/go-away/tests/snapshots/output__struct_enum.snap
+++ b/go-away/tests/snapshots/output__struct_enum.snap
@@ -3,25 +3,19 @@ source: go-away/tests/output.rs
 expression: "go_away::registry_to_output(registry)"
 
 ---
-type OptionOne struct {
-	X string `json:"x"`
-	Y int `json:"y"`
+type OptionTwo struct {
+	Foo string `json:"foo"`
+	Bar Nested `json:"bar"`
 }
 type Nested struct {
 	AString string `json:"some_other_name"`
 	AnInt int `json:"an_int"`
 	FulfilmentType FulfilmentType `json:"fulfilment_type"`
 }
-type OptionTwo struct {
-	Foo string `json:"foo"`
-	Bar Nested `json:"bar"`
+type OptionOne struct {
+	X string `json:"x"`
+	Y int `json:"y"`
 }
-type FulfilmentType string
-
-const (
-	Delivery FulfilmentType = "Delivery"
-	Collection FulfilmentType = "Collection"
-)
 type StructEnum struct {
 	*OptionOne
 	*OptionTwo
@@ -72,4 +66,10 @@ func (self *StructEnum) UnmarshalJSON(data []byte) error {
 	}
 	return nil
 }
+type FulfilmentType string
+
+const (
+	Delivery FulfilmentType = "Delivery"
+	Collection FulfilmentType = "Collection"
+)
 

--- a/go-away/tests/snapshots/output__struct_output.snap
+++ b/go-away/tests/snapshots/output__struct_output.snap
@@ -3,14 +3,14 @@ source: go-away/tests/output.rs
 expression: "go_away::registry_to_output(registry)"
 
 ---
+type MyData struct {
+	FieldOne string `json:"field_one"`
+	Nested Nested `json:"nested"`
+}
 type Nested struct {
 	AString string `json:"some_other_name"`
 	AnInt int `json:"an_int"`
 	FulfilmentType FulfilmentType `json:"fulfilment_type"`
-}
-type MyData struct {
-	FieldOne string `json:"field_one"`
-	Nested Nested `json:"nested"`
 }
 type FulfilmentType string
 

--- a/go-away/tests/snapshots/output__type_deduplication.snap
+++ b/go-away/tests/snapshots/output__type_deduplication.snap
@@ -3,29 +3,23 @@ source: go-away/tests/output.rs
 expression: "go_away::registry_to_output(registry)"
 
 ---
-type OptionOne struct {
-	X string `json:"x"`
-	Y int `json:"y"`
+type MyData struct {
+	FieldOne string `json:"field_one"`
+	Nested Nested `json:"nested"`
+}
+type OptionTwo struct {
+	Foo string `json:"foo"`
+	Bar Nested `json:"bar"`
 }
 type Nested struct {
 	AString string `json:"some_other_name"`
 	AnInt int `json:"an_int"`
 	FulfilmentType FulfilmentType `json:"fulfilment_type"`
 }
-type OptionTwo struct {
-	Foo string `json:"foo"`
-	Bar Nested `json:"bar"`
+type OptionOne struct {
+	X string `json:"x"`
+	Y int `json:"y"`
 }
-type MyData struct {
-	FieldOne string `json:"field_one"`
-	Nested Nested `json:"nested"`
-}
-type FulfilmentType string
-
-const (
-	Delivery FulfilmentType = "Delivery"
-	Collection FulfilmentType = "Collection"
-)
 type StructEnum struct {
 	*OptionOne
 	*OptionTwo
@@ -76,4 +70,10 @@ func (self *StructEnum) UnmarshalJSON(data []byte) error {
 	}
 	return nil
 }
+type FulfilmentType string
+
+const (
+	Delivery FulfilmentType = "Delivery"
+	Collection FulfilmentType = "Collection"
+)
 


### PR DESCRIPTION
This adjusts the output of the types - we do a post-order traversal of
the graph so this should put the root types first instead of last like
they are currently.  This isn't perfect but does seem better than what
was happening before

Related to #8 