### PR TITLE
Fix newtype detection.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ all APIs might be changed.
 
 - Go union type output is now more likely to compile (it didn't at all prior to
   this)
+- Single field structs are no longer considered newtypes
 
 ### Changes
 

--- a/go-away-derive-internals/src/type_metadata_derive/snapshots/go_away_derive_internals__type_metadata_derive__tests__newtype_struct.snap
+++ b/go-away-derive-internals/src/type_metadata_derive/snapshots/go_away_derive_internals__type_metadata_derive__tests__newtype_struct.snap
@@ -1,0 +1,16 @@
+---
+source: go-away-derive-internals/src/type_metadata_derive/mod.rs
+expression: "test_conversion(quote! { struct MyData(String) ; })"
+
+---
+#[automatically_derived]
+impl ::go_away::TypeMetadata for MyData {
+    fn metadata(registry: &mut ::go_away::TypeRegistry) -> ::go_away::types::FieldType {
+        use go_away::types::{self, FieldType};
+        let nt = types::NewType {
+            name: "MyData".to_string(),
+            inner: <String as ::go_away::TypeMetadata>::metadata(registry),
+        };
+        FieldType::Named(registry.register_newtype(::go_away::TypeId::for_type::<MyData>(), nt))
+    }
+}

--- a/go-away-derive-internals/src/type_metadata_derive/snapshots/go_away_derive_internals__type_metadata_derive__tests__struct_with_single_field.snap
+++ b/go-away-derive-internals/src/type_metadata_derive/snapshots/go_away_derive_internals__type_metadata_derive__tests__struct_with_single_field.snap
@@ -1,0 +1,24 @@
+---
+source: go-away-derive-internals/src/type_metadata_derive/mod.rs
+expression: "test_conversion(quote! { struct MyData { data : String } })"
+
+---
+#[automatically_derived]
+impl ::go_away::TypeMetadata for MyData {
+    fn metadata(registry: &mut ::go_away::TypeRegistry) -> ::go_away::types::FieldType {
+        use go_away::types::{self, FieldType};
+        let type_ref = {
+            let mut st = types::Struct {
+                name: "MyData".into(),
+                fields: vec![],
+            };
+            st.fields.push(types::Field {
+                name: "data".into(),
+                serialized_name: "data".into(),
+                ty: <String as ::go_away::TypeMetadata>::metadata(registry),
+            });
+            registry.register_struct(::go_away::TypeId::for_type::<MyData>(), st)
+        };
+        FieldType::Named(type_ref)
+    }
+}

--- a/go-away/tests/snapshots/output__internally_tagged_tuple_enum.snap
+++ b/go-away/tests/snapshots/output__internally_tagged_tuple_enum.snap
@@ -3,6 +3,12 @@ source: go-away/tests/output.rs
 expression: "go_away::registry_to_output(registry)"
 
 ---
+type Two struct {
+	Y bool `json:"y"`
+}
+type One struct {
+	X float64 `json:"x"`
+}
 type InternallyTaggedTupleEnum struct {
 	One *One
 	Two *Two
@@ -55,6 +61,4 @@ func (self *InternallyTaggedTupleEnum) UnmarshalJSON(data []byte) error {
 	}
 	return nil
 }
-type Two bool
-type One float64
 

--- a/go-away/tests/snapshots/output__newtype_enum.snap
+++ b/go-away/tests/snapshots/output__newtype_enum.snap
@@ -3,6 +3,12 @@ source: go-away/tests/output.rs
 expression: "go_away::registry_to_output(registry)"
 
 ---
+type Two struct {
+	Y bool `json:"y"`
+}
+type One struct {
+	X float64 `json:"x"`
+}
 type NewTypeEnum struct {
 	OptionOne *One
 	OptionTwo *Two
@@ -53,6 +59,4 @@ func (self *NewTypeEnum) UnmarshalJSON(data []byte) error {
 	}
 	return nil
 }
-type Two bool
-type One float64
 


### PR DESCRIPTION
Previously we were considering any struct with one field as a newtype,
even if it's field was named.  This updates it to use the
serde_derive_internals style enum instead.

Fixes #14