### PR TITLE
Prefix enum variant constants with type name.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ all APIs might be changed.
 
 ## Unreleased - xxxx-xx-xx
 
+### Breaking Changes
+
+- Enums variant constants now prefixed with their type name to avoid clashes.
+
 ### New Features
 
 - Internally tagged enums are now supported

--- a/go-away/src/output.rs
+++ b/go-away/src/output.rs
@@ -30,7 +30,8 @@ impl<'a> fmt::Display for GoType<'a> {
                 for variant in &details.variants {
                     writeln!(
                         indented(f),
-                        "{} {} = \"{}\"",
+                        "{}_{} {} = \"{}\"",
+                        details.name,
                         variant.name,
                         details.name,
                         variant.serialized_name
@@ -432,8 +433,8 @@ mod tests {
         type FulfilmentType string
 
         const (
-        	Delivery FulfilmentType = "DELIVERY"
-        	Collection FulfilmentType = "COLLECTION"
+        	FulfilmentType_Delivery FulfilmentType = "DELIVERY"
+        	FulfilmentType_Collection FulfilmentType = "COLLECTION"
         )
         "###);
     }

--- a/go-away/tests/snapshots/output__struct_enum.snap
+++ b/go-away/tests/snapshots/output__struct_enum.snap
@@ -69,7 +69,7 @@ func (self *StructEnum) UnmarshalJSON(data []byte) error {
 type FulfilmentType string
 
 const (
-	Delivery FulfilmentType = "Delivery"
-	Collection FulfilmentType = "Collection"
+	FulfilmentType_Delivery FulfilmentType = "Delivery"
+	FulfilmentType_Collection FulfilmentType = "Collection"
 )
 

--- a/go-away/tests/snapshots/output__struct_output.snap
+++ b/go-away/tests/snapshots/output__struct_output.snap
@@ -15,7 +15,7 @@ type Nested struct {
 type FulfilmentType string
 
 const (
-	Delivery FulfilmentType = "Delivery"
-	Collection FulfilmentType = "Collection"
+	FulfilmentType_Delivery FulfilmentType = "Delivery"
+	FulfilmentType_Collection FulfilmentType = "Collection"
 )
 

--- a/go-away/tests/snapshots/output__type_deduplication.snap
+++ b/go-away/tests/snapshots/output__type_deduplication.snap
@@ -73,7 +73,7 @@ func (self *StructEnum) UnmarshalJSON(data []byte) error {
 type FulfilmentType string
 
 const (
-	Delivery FulfilmentType = "Delivery"
-	Collection FulfilmentType = "Collection"
+	FulfilmentType_Delivery FulfilmentType = "Delivery"
+	FulfilmentType_Collection FulfilmentType = "Collection"
 )
 


### PR DESCRIPTION
Rust supports having enums with clashing variant names.  These result in
invalid go output though as we were just using the variant name directly
for the enum variant constants.

This change prefixes the variant constants with the type name to avoid
clashes.

Fixes #13 