### PR TITLE
Remove the underscores from enum variant constants.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ all APIs might be changed.
 
 ## Unreleased - xxxx-xx-xx
 
+### Breaking Changes
+
+- Enum variant constants no longer contain underscores.
+
 ## v0.2.0 - 2021-06-06
 
 ### Breaking Changes

--- a/go-away/src/output.rs
+++ b/go-away/src/output.rs
@@ -30,7 +30,7 @@ impl<'a> fmt::Display for GoType<'a> {
                 for variant in &details.variants {
                     writeln!(
                         indented(f),
-                        "{}_{} {} = \"{}\"",
+                        "{}{} {} = \"{}\"",
                         details.name,
                         variant.name,
                         details.name,
@@ -433,8 +433,8 @@ mod tests {
         type FulfilmentType string
 
         const (
-        	FulfilmentType_Delivery FulfilmentType = "DELIVERY"
-        	FulfilmentType_Collection FulfilmentType = "COLLECTION"
+        	FulfilmentTypeDelivery FulfilmentType = "DELIVERY"
+        	FulfilmentTypeCollection FulfilmentType = "COLLECTION"
         )
         "###);
     }

--- a/go-away/tests/snapshots/output__struct_enum.snap
+++ b/go-away/tests/snapshots/output__struct_enum.snap
@@ -69,7 +69,7 @@ func (self *StructEnum) UnmarshalJSON(data []byte) error {
 type FulfilmentType string
 
 const (
-	FulfilmentType_Delivery FulfilmentType = "Delivery"
-	FulfilmentType_Collection FulfilmentType = "Collection"
+	FulfilmentTypeDelivery FulfilmentType = "Delivery"
+	FulfilmentTypeCollection FulfilmentType = "Collection"
 )
 

--- a/go-away/tests/snapshots/output__struct_output.snap
+++ b/go-away/tests/snapshots/output__struct_output.snap
@@ -15,7 +15,7 @@ type Nested struct {
 type FulfilmentType string
 
 const (
-	FulfilmentType_Delivery FulfilmentType = "Delivery"
-	FulfilmentType_Collection FulfilmentType = "Collection"
+	FulfilmentTypeDelivery FulfilmentType = "Delivery"
+	FulfilmentTypeCollection FulfilmentType = "Collection"
 )
 

--- a/go-away/tests/snapshots/output__type_deduplication.snap
+++ b/go-away/tests/snapshots/output__type_deduplication.snap
@@ -73,7 +73,7 @@ func (self *StructEnum) UnmarshalJSON(data []byte) error {
 type FulfilmentType string
 
 const (
-	FulfilmentType_Delivery FulfilmentType = "Delivery"
-	FulfilmentType_Collection FulfilmentType = "Collection"
+	FulfilmentTypeDelivery FulfilmentType = "Delivery"
+	FulfilmentTypeCollection FulfilmentType = "Collection"
 )
 


### PR DESCRIPTION
Our enum constants were being output as `TypeName_VariantName`.  Go prefers
camel/pascal case and some IDEs will complain if they see underscores.  So this
updates the output to `TypeNameVariantName`.